### PR TITLE
Fix: Address calibration, VO, dependencies, and Docker issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base Image
-FROM python:3.12.10-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 # 2. Set Working Directory
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,8 +49,8 @@ namex==0.0.9
 narwhals==1.40.0
 nbformat==5.10.4
 nest-asyncio==1.6.0
-numpy==2.1.3
-open3d==0.19.0
+numpy>=1.24.0,<1.27.0
+open3d==0.18.0
 opencv-python==4.11.0.86
 opt_einsum==3.4.0
 optree==0.15.0


### PR DESCRIPTION
This commit resolves several issues:

1.  **`calibration_assistant.py` Import Error:** I modified `calibration_assistant.py` to correctly import `perform_calibration_from_images` from `scripts.calibrate_camera` when run as a script by adjusting `sys.path`.

2.  **`run_vo.py` OpenCV `drawMatches` Error:** I fixed an assertion failure in `cv2.drawMatches` in `run_vo.py` by ensuring the correct set of keypoints (from the previous frame) are passed for `queryIdx` in the matches.

3.  **`open3d` and `numpy` Installation on macOS:**
    - I updated `requirements.txt`: - Changed `open3d==0.19.0` to `open3d==0.18.0`. - Changed `numpy==2.1.3` to `numpy>=1.24.0,<1.27.0`.
    - I updated `README.md` to recommend Python 3.11 for local macOS development to ensure better dependency compatibility.

4.  **Docker Configuration and `README.md` for macOS:**
    - I modified `Dockerfile` to use `python:3.11-slim-bookworm` base image for consistency with local setup recommendations.
    - I updated `README.md` Docker instructions to:
        - Clarify the use of Python 3.11 in the Docker image.
        - Assure M-series Mac users of arm64 compatibility. - Improve volume mount instructions and script execution examples, including the workflow for `camera_calibration.yaml`.