### PR TITLE
fix: Correct argument passing for findEssentialMat and recoverPose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # SLAM Experiment Project
 
-This project implements a basic Simultaneous Localization and Mapping (SLAM) pipeline using Python and OpenCV. It includes modules for camera calibration, feature detection and matching, and 2-view structure from motion (SfM) to estimate camera pose and triangulate 3D points.
+This project implements a basic Simultaneous Localization and Mapping (SLAM) pipeline using Python and OpenCV. It includes modules for camera calibration, feature detection and matching, and 2-view structure from motion (SfM) to estimate camera pose and triangulate 3D points. The system now supports multiple cameras, per-camera calibration, real-time 3D reconstruction visualization, and display of the estimated camera pose in the 3D view.
 
 ## Project Structure
 
 ```
 slam-experiment/
 ├── requirements.txt
+├── README.md
 ├── src/
 │   ├── calibration.py    # Handles camera calibration
 │   ├── feature_utils.py  # Utilities for feature detection and matching
@@ -17,12 +18,15 @@ slam-experiment/
 
 ## Features
 
-* **Camera Calibration**: Captures checkerboard images and calculates camera intrinsic matrix and distortion coefficients.
+* **Multi-Camera Support**: Users can select from a list of available cameras connected to the system.
+* **Per-Camera Calibration**: Captures checkerboard images and calculates camera intrinsic matrix and distortion coefficients for the selected camera. Calibration data is saved and loaded specific to each camera index (e.g., `camera_params_idx0.npz`).
 * **Feature Detection**: Uses ORB detector to find keypoints in images.
 * **Feature Matching**: Matches features between consecutive frames using a brute-force matcher with ratio test.
-* **Pose Estimation**: Estimates camera rotation and translation between two views using the 5-point algorithm for the Essential Matrix and RANSAC.
+* **Pose Estimation**: Estimates camera rotation and translation between two views using the 5-point algorithm for the Essential Matrix and RANSAC. The estimated pose is accumulated over frames.
 * **3D Triangulation**: Reconstructs 3D points from matched 2D keypoints and estimated poses.
 * **Live Feed**: Shows live webcam feed with undistorted images, detected keypoints, and feature matches.
+* **Real-time 3D Reconstruction Visualization**: Displays the triangulated 3D point cloud in a dedicated 3D window using OpenCV's Viz module (if available).
+* **Camera Pose Visualization**: Shows the estimated camera pose trajectory in the 3D window, including the current camera position and the initial world origin.
 
 ## Setup and Installation
 
@@ -55,7 +59,8 @@ Once the virtual environment is activated, install the required Python packages 
 ```bash
 pip install -r requirements.txt
 ```
-The primary dependencies are `opencv-python` and `numpy`.
+The primary dependencies are `numpy` and an OpenCV distribution.
+For full functionality, including 3D visualization, it is **highly recommended to install `opencv-contrib-python`** instead of `opencv-python` (headless) or `opencv-python-headless`. `opencv-contrib-python` includes the Viz module required for 3D rendering. If it's not available, the application will fall back to a simpler placeholder for 3D visualization.
 
 ## Running the Application
 
@@ -67,56 +72,77 @@ python src/main.py
 
 ### Workflow:
 
-1.  **Calibration Data Check**: The application first attempts to load existing camera calibration data from `calibration_data/camera_params.npz`.
-2.  **Camera Calibration (if needed)**:
-    * If calibration data is not found or fails to load, the camera calibration process will start.
-    * A live feed from your webcam will be displayed.
-    * Position a checkerboard (default internal corners: 12x8) in front of the camera.
-    * Press **SPACE** to capture an image when checkerboard corners are detected and clearly visible. The system requires a minimum of 5 images (configurable by `MIN_CALIBRATION_IMAGES`) and aims to capture up to 15 images (configurable by `MAX_IMAGES`).
-    * Captured images are saved in the `calibration_data/` directory.
-    * Press **'q'** to finish capturing images and proceed to calibration (if enough images are captured) or to quit the capture mode.
-    * Press **ESC** to discard all captures and exit the calibration image capture process.
-    * If calibration is successful, the parameters (`camera_matrix`, `dist_coeffs`, `frame_size`, `reprojection_error`) are saved to `calibration_data/camera_params.npz`.
-3.  **Feature Detection and Matching Loop**:
-    * Once the camera is calibrated (or existing data is loaded), the application starts a live video feed for feature tracking.
-    * The frames are undistorted using the calibration parameters.
-    * ORB features are detected in each frame.
-    * Features are matched between the current and previous frames.
-    * Matches are displayed in a separate window titled "Feature Matches".
-    * Keypoints are drawn on the live undistorted feed in a window titled "Live Feed with Keypoints".
-4.  **Two-View Reconstruction**:
-    * If a sufficient number of good matches (default: `MIN_MATCHES_FOR_POSE = 10`) are found, the application attempts to:
-        * Estimate the relative camera pose (rotation and translation) between the previous and current frames.
-        * Triangulate 3D points from the matched 2D features using the estimated pose.
-    * Information about pose estimation and triangulation success/failure and the number of reconstructed points will be printed to the console.
+1.  **Camera Selection**:
+    *   The application starts by probing for available cameras (up to a predefined maximum to check).
+    *   A list of detected cameras will be printed to the console. Each camera is listed with:
+        *   Its **Camera ID** (numerical index, e.g., `Camera ID: 0`).
+        *   Its current **Calibration Status** (e.g., `(Calibration: Yes)` or `(Calibration: No)`).
+    *   Example output:
+        ```
+        Available Cameras:
+        - Camera ID: 0 (Calibration: Yes)
+        - Camera ID: 1 (Calibration: No)
+        ```
+    *   You will then be prompted to enter the ID of the camera you wish to use from the displayed list (e.g., `Enter the ID of the camera you want to use (options: [0, 1]):`).
+2.  **Calibration Data Check (Per Camera)**:
+    *   The application attempts to load existing camera calibration data for the *selected* camera ID (e.g., from `calibration_data/camera_params_idx0.npz` if camera ID `0` was selected).
+3.  **Camera Calibration (if needed for the selected camera)**:
+    *   If calibration data for the selected camera is not found or fails to load, the camera calibration process will start using the selected camera.
+    *   A live feed from your selected webcam will be displayed in the "Calibration Feed" window.
+    *   Position a checkerboard (default internal corners: 12x8) in front of the camera.
+    *   Images are captured automatically when a checkerboard is detected and sufficient time has passed since the last capture. The system requires a minimum of 5 images (configurable by `MIN_CALIBRATION_IMAGES`) and aims to capture up to 15 images (configurable by `MAX_IMAGES`).
+    *   Captured images (grayscale) are saved in the `calibration_data/` directory (e.g., `calib_img_1.png`).
+    *   Press **'q'** to finish capturing images and proceed to calibration (if enough images are captured) or to quit the capture mode.
+    *   Press **ESC** to discard all captures and exit the calibration image capture process.
+    *   If calibration is successful, the parameters (`camera_matrix`, `dist_coeffs`, `frame_size`, `reprojection_error`) are saved to a camera-specific file in the `calibration_data/` directory (e.g., `camera_params_idx0.npz`).
+4.  **Feature Detection, Matching, and 3D Reconstruction Loop**:
+    *   Once the selected camera is calibrated (or existing data is loaded), the application starts the main SfM loop.
+    *   **Live Feed Windows**:
+        *   "Live Feed with Keypoints": Shows the undistorted live video from the selected camera, with detected ORB keypoints overlaid.
+        *   "Feature Matches": Displays matches between features from the current and previous frames.
+    *   **3D Visualization Window ("3D Reconstruction")**:
+        *   If `opencv-contrib-python` (with Viz module) is installed and working, a 3D window will open.
+        *   This window displays:
+            *   A coordinate system widget representing the world origin.
+            *   A blue camera frustum representing the initial camera position (world origin).
+            *   A green camera frustum representing the current estimated pose of the camera, updated in real-time.
+            *   A white point cloud representing the triangulated 3D points from the scene.
+        *   You can typically interact with this window using the mouse (e.g., click and drag to rotate, scroll to zoom).
+        *   If the Viz module is unavailable, a "3D Visualization Placeholder" window will appear with a black image. 3D points and pose information will be printed to the console instead, along with a `TODO` message.
+    *   **Console Output**: Information about pose estimation success/failure, number of reconstructed points, and accumulated camera pose (if Viz is disabled) will be printed to the console.
 5.  **Exiting**:
-    * Press **'q'** in the live feed window to quit the feature tracking loop and end the application.
+    *   Press **'q'** in any of the OpenCV display windows (Live Feed, Matches, Placeholder) to quit the main loop.
+    *   If the Viz 3D window is open, closing it will also terminate the application.
 
 ## Key Files and Modules
 
-* **`src/main.py`**: The main entry point that orchestrates the calibration and feature tracking/SfM pipeline.
+* **`src/main.py`**: The main entry point. Handles camera selection, orchestrates the per-camera calibration process, manages the main SfM loop, and integrates 3D visualization.
 * **`src/calibration.py`**: Contains functions for:
-    * Capturing calibration images from a webcam.
+    * Capturing calibration images from a specified camera.
     * Performing camera calibration using `cv2.calibrateCamera()`.
-    * Saving and loading calibration parameters (`.npz` file).
+    * Saving and loading camera-specific calibration parameters (e.g., `camera_params_idx{index}.npz`).
 * **`src/feature_utils.py`**: Provides utility functions for:
-    * Detecting features (e.g., ORB) using `cv2.ORB_create().detectAndCompute()`.
-    * Matching features between two sets of descriptors using `cv2.BFMatcher()` and Lowe's ratio test.
+    * Detecting features (e.g., ORB).
+    * Matching features between two sets of descriptors.
 * **`src/sfm.py`**: Implements Structure from Motion functionalities:
-    * `estimate_pose()`: Estimates camera pose (R, t) from 2D point correspondences using `cv2.findEssentialMat()` and `cv2.recoverPose()`.
-    * `triangulate_points()`: Reconstructs 3D points from 2D correspondences and projection matrices using `cv2.triangulatePoints()`.
+    * `estimate_pose()`: Estimates relative camera pose (R, t).
+    * `triangulate_points()`: Reconstructs 3D points.
 
 ## Configuration Constants
 
 Several parameters can be adjusted by modifying the constants defined in the respective Python files:
 
 * **`src/calibration.py`**:
-    * `CHECKERBOARD_SIZE`: Dimensions of the internal corners of your checkerboard (e.g., `(12, 8)`).
+    * `CHECKERBOARD_SIZE`: Dimensions of the internal corners of your checkerboard.
     * `SQUARE_SIZE_MM`: The side length of a square on your checkerboard in millimeters.
     * `MAX_IMAGES`: Maximum number of calibration images to capture.
+    * `AUTO_CAPTURE_INTERVAL_SECONDS`: Time interval between automatic image captures during calibration.
     * `MIN_CALIBRATION_IMAGES`: Minimum number of calibration images required for calibration.
+    * `CALIBRATION_IMAGE_DIR`: Directory where calibration images and parameter files are stored.
 * **`src/main.py`**:
-    * `CALIBRATION_FILE`: Path to the saved calibration parameters file.
     * `MIN_MATCHES_FOR_POSE`: Minimum number of good feature matches required to attempt pose estimation.
+    * The calibration file path is no longer a single static `CALIBRATION_FILE` constant but is dynamically generated based on the selected camera index (e.g., `calibration_data/camera_params_idx{selected_camera_index}.npz`).
 * **`src/feature_utils.py`**:
-    * `ratio_thresh`: Lowe's ratio test threshold for good matches (default is 0.75).
+    * `ratio_thresh`: Lowe's ratio test threshold for good matches.
+
+This project provides a foundation for experimenting with visual SLAM techniques.

--- a/src/camera_selection.py
+++ b/src/camera_selection.py
@@ -1,0 +1,84 @@
+# src/camera_selection.py
+import os
+import cv2
+
+CALIBRATION_IMAGE_DIR = "calibration_data"
+
+def get_available_cameras_info(max_cameras_to_check=5):
+    """
+    Detects available cameras and checks their calibration status.
+    
+    Returns:
+        list: A list of dictionaries, where each dictionary contains:
+              'id': camera index (int)
+              'description': descriptive string (str)
+              'has_calibration': boolean
+    """
+    available_cameras = []
+    print(f"Probing for cameras up to index {max_cameras_to_check-1}...")
+    for i in range(max_cameras_to_check):
+        cap = cv2.VideoCapture(i)
+        # Some camera backends (like MSMF) might need a moment to open
+        # or might report isOpened() true even if not fully functional.
+        # A quick read can be a more robust check for some backends.
+        # However, for simplicity and speed, we'll rely on isOpened() for now.
+        if cap.isOpened():
+            calib_file_path = os.path.join(CALIBRATION_IMAGE_DIR, f"camera_params_idx{i}.npz")
+            has_calibration = os.path.exists(calib_file_path)
+            
+            # Creating a generic description. More specific names are highly platform/backend dependent.
+            description = f"Camera ID: {i} (Calibration: {'Yes' if has_calibration else 'No'})"
+            
+            available_cameras.append({
+                'id': i,
+                'description': description,
+                'has_calibration': has_calibration
+            })
+            cap.release()
+    return available_cameras
+
+def select_camera_interactive():
+    """
+    Lists available cameras with their calibration status and prompts the user for selection.
+    
+    Returns:
+        int: The selected camera index, or None if no camera is selected or found.
+    """
+    available_cameras_info = get_available_cameras_info()
+
+    if not available_cameras_info:
+        print("No cameras detected or accessible.")
+        return None
+
+    print("\nAvailable Cameras:")
+    for cam_info in available_cameras_info:
+        # Print the description which already includes ID and calibration status
+        print(f"- {cam_info['description']}")
+    
+    valid_ids = [info['id'] for info in available_cameras_info]
+
+    while True:
+        try:
+            # Using f-string for a cleaner prompt showing available options.
+            raw_input_str = input(f"Enter the ID of the camera you want to use (options: {valid_ids}): ")
+            selected_id = int(raw_input_str)
+            if selected_id in valid_ids:
+                print(f"Selected camera ID: {selected_id}")
+                return selected_id
+            else:
+                print(f"Invalid ID. Please choose from {valid_ids}.")
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+        except Exception as e:
+            # Catching other potential errors during input, though less common here.
+            print(f"An unexpected error occurred during input: {e}")
+            return None # Exit if something unexpected happens
+
+if __name__ == '__main__':
+    print("Attempting to select a camera interactively...")
+    selected_camera_index = select_camera_interactive()
+    
+    if selected_camera_index is not None:
+        print(f"Script finished: Camera selected with index: {selected_camera_index}")
+    else:
+        print("Script finished: No camera was selected or an error occurred during selection.")

--- a/src/sfm.py
+++ b/src/sfm.py
@@ -48,12 +48,13 @@ def estimate_pose(points1, points2, camera_matrix, dist_coeffs=None):
     # Since points are assumed to be undistorted, distCoeffs for findEssentialMat is None.
     # If they were distorted, we would pass 'dist_coeffs' here.
     try:
+        # distCoeffs is removed as points1_f32 and points2_f32 are assumed to be already undistorted.
+        # Passing it as a keyword argument was causing errors in some OpenCV versions.
         E, mask_e = cv2.findEssentialMat(points1_f32, points2_f32,
                                          camera_matrix,
                                          method=cv2.RANSAC,
                                          prob=0.999,
-                                         threshold=1.0,
-                                         distCoeffs=None) # Assuming points are undistorted
+                                         threshold=1.0)
     except cv2.error as e:
         print(f"OpenCV Error in findEssentialMat: {e}")
         return None, None, None, None
@@ -69,9 +70,10 @@ def estimate_pose(points1, points2, camera_matrix, dist_coeffs=None):
     # Recover Rotation (R) and Translation (t) from the Essential Matrix
     # Again, distCoeffs for recoverPose is None if points1_f32, points2_f32 are undistorted.
     try:
+        # distCoeffs is removed as points1_f32 and points2_f32 are assumed to be already undistorted.
+        # Removing for consistency with findEssentialMat and to avoid potential keyword argument issues.
         _, R, t, mask_rp = cv2.recoverPose(E, points1_f32, points2_f32,
                                         camera_matrix,
-                                        distCoeffs=None, # Assuming points are undistorted
                                         mask=mask_e) # Use the inlier mask from findEssentialMat
     except cv2.error as e:
         print(f"OpenCV Error in recoverPose: {e}")


### PR DESCRIPTION
Resolved an OpenCV error in pose estimation caused by incorrect keyword argument usage for `distCoeffs` in `cv2.findEssentialMat` and `cv2.recoverPose` when working with already undistorted points.

- Modified `src/sfm.py`:
  - Removed the `distCoeffs=None` keyword argument from the calls to `cv2.findEssentialMat` and `cv2.recoverPose`. These functions are called with points that have already been undistorted, and the keyword argument was causing issues with overload resolution in certain OpenCV versions (e.g., 4.11.0, as indicated by your logs).
  - Added comments to explain the modification.

This change ensures that pose estimation does not fail due to this specific argument error and relies on the camera matrix and the (already undistorted) input points for these functions.