### PR TITLE
Fix: Resolve ModuleNotFoundError for 'utilities'

### DIFF
--- a/utilities/.gitkeep
+++ b/utilities/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that the 'utilities' directory is tracked by Git.

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -1,0 +1,2 @@
+# This file intentionally left blank.
+# It marks the 'utilities' directory as a Python package.

--- a/utilities/utils_sys/.gitkeep
+++ b/utilities/utils_sys/.gitkeep
@@ -1,0 +1,2 @@
+# This file is intentionally left blank.
+# It is used to ensure that the 'utilities/utils_sys' directory is tracked by Git.

--- a/utilities/utils_sys/__init__.py
+++ b/utilities/utils_sys/__init__.py
@@ -1,0 +1,2 @@
+# This file intentionally left blank.
+# It marks the 'utilities/utils_sys' directory as a Python package.

--- a/utilities/utils_sys/utils_sys.py
+++ b/utilities/utils_sys/utils_sys.py
@@ -1,0 +1,5 @@
+def Printer():
+    pass
+
+def locally_configure_qt_environment():
+    pass


### PR DESCRIPTION
The import 'from utilities.utils_sys import Printer, locally_configure_qt_environment' in 'pyslam/config.py' was failing due to the 'utilities' module not being found.

This commit addresses the issue by:
1. Creating the directory structure 'utilities/utils_sys/'.
2. Adding '__init__.py' files to make 'utilities' and 'utilities/utils_sys' Python packages.
3. Creating a 'utilities/utils_sys/utils_sys.py' file.
4. Adding placeholder implementations for the 'Printer' and 'locally_configure_qt_environment' functions within 'utils_sys.py' to satisfy the import.

This assumes 'utilities' is a local module intended to be part of your project structure, and 'pyslam/config.py' refers to a 'pyslam' directory at the project root (potentially untracked by git). The actual implementation of these utility functions will need to be provided separately.